### PR TITLE
fix: allow unsafe-eval in production CSP and remove unused variable

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,10 +21,9 @@ if (!process.env.VELITE_STARTED && (isDev || isBuild)) {
   }
 }
 
-const isDevEnv = process.env.NODE_ENV === 'development'
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' ${isDevEnv ? "'unsafe-eval'" : ''} 'unsafe-inline' static.cloudflareinsights.com;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' static.cloudflareinsights.com;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src *.s3.amazonaws.com;


### PR DESCRIPTION
Add 'unsafe-eval' to script-src for all environments to fix EvalError from library code using new Function() in production. Remove isDevEnv variable that is no longer referenced.