### PR TITLE
fix: production 빌드에서 draft 포스트가 노출되는 문제 수정

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -9,6 +9,7 @@ import { Metadata } from 'next'
 import siteMetadata from '@/data/siteMetadata'
 import { notFound } from 'next/navigation'
 
+const isProduction = process.env.NODE_ENV === 'production'
 const defaultLayout = 'PostLayout'
 const layouts = {
   PostLayout,
@@ -22,10 +23,10 @@ export async function generateMetadata({
   const { slug: slugParts } = await params
   const slug = decodeURI(slugParts.join('/'))
   const post = allBlogs.find((p) => p.slug === slug)
-  const authorList = post?.authors || ['default']
-  if (!post) {
+  if (!post || (isProduction && post.draft)) {
     return
   }
+  const authorList = post.authors || ['default']
   const authorDetails = authorList
     .map((author) => {
       const authorResults = allAuthors.find((p) => p.slug === author)
@@ -72,7 +73,8 @@ export async function generateMetadata({
 }
 
 export const generateStaticParams = async () => {
-  const paths = allBlogs.map((p) => ({ slug: p.slug.split('/') }))
+  const blogs = isProduction ? allBlogs.filter((p) => !p.draft) : allBlogs
+  const paths = blogs.map((p) => ({ slug: p.slug.split('/') }))
 
   return paths
 }
@@ -90,7 +92,7 @@ export default async function Page({ params }: { params: Promise<{ slug: string[
   const prev = sortedCoreContents[postIndex + 1]
   const next = sortedCoreContents[postIndex - 1]
   const post = allBlogs.find((p) => p.slug === slug)
-  if (!post) notFound()
+  if (!post || (isProduction && post.draft)) notFound()
   const authorList = post.authors || ['default']
   const authorDetails = authorList
     .map((author) => {

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -6,7 +6,8 @@ import { getTagCounts } from '@/lib/tagCounts'
 const POSTS_PER_PAGE = 5
 
 export const generateStaticParams = async () => {
-  const totalPages = Math.ceil(allBlogs.length / POSTS_PER_PAGE)
+  const posts = allCoreContent(sortPosts(allBlogs))
+  const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE)
   const paths = Array.from({ length: totalPages }, (_, i) => ({ page: (i + 1).toString() }))
 
   return paths

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,9 +2,12 @@ import { MetadataRoute } from 'next'
 import { allBlogs } from '@/lib/contentlayer'
 import siteMetadata from '@/data/siteMetadata'
 
+const isProduction = process.env.NODE_ENV === 'production'
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const siteUrl = siteMetadata.siteUrl
-  const blogRoutes = allBlogs.map((post) => ({
+  const blogs = isProduction ? allBlogs.filter((post) => !post.draft) : allBlogs
+  const blogRoutes = blogs.map((post) => ({
     url: `${siteUrl}/${post.path}`,
     lastModified: post.lastmod || post.date,
   }))


### PR DESCRIPTION
## 변경 사항
- `app/blog/[...slug]/page.tsx`: `generateStaticParams`, `generateMetadata`, 본문 렌더링에서 production 환경일 때 draft 포스트 필터링
- `app/blog/page/[page]/page.tsx`: `generateStaticParams`에서 draft 제외된 포스트 수 기준으로 페이지네이션 계산
- `app/sitemap.ts`: production 환경에서 draft 포스트를 sitemap에서 제외

## 변경 유형
- [x] 버그 수정

## 확인 사항
- [ ] 로컬에서 빌드(`yarn build`) 정상 동작
- [ ] 브라우저에서 변경 내용 확인