### PR TITLE
docs(blog): 로지스틱 회귀 밑바닥부터 구현 포스트 추가

### DIFF
--- a/data/blog/ML/logistic-regression-from-scratch.mdx
+++ b/data/blog/ML/logistic-regression-from-scratch.mdx
@@ -1,0 +1,289 @@
+---
+title: 'NumPy로 로지스틱 회귀 밑바닥부터 구현하기'
+date: '2026-04-21'
+tags: ['ML', 'math', 'numpy']
+draft: false
+summary: Logistic Regression from Scratch
+---
+
+[TensorTonic의 Logistic Regression 문제](https://www.tensortonic.com/study-plans/cracking-ml/ml-logistic-regression)를 NumPy만 사용해서 경사하강법으로 풀면서 정리했다. 선형 회귀에서 이어지는 내용이지만 BCE 손실 함수와 시그모이드 미분이 조합되는 지점이 핵심이라 그 부분을 중심으로 다룬다.
+
+# 로지스틱 회귀 모델
+
+로지스틱 회귀는 입력 특성 $\mathbf{x} \in \mathbb{R}^d$를 받아 **이진 라벨** $y \in \{0, 1\}$을 예측한다. 선형 회귀처럼 연속값을 바로 뱉을 수는 없으니 선형 결합을 시그모이드에 통과시켜 $(0, 1)$ 범위의 **확률**로 변환한다.
+
+$$
+z = \mathbf{w}^\top \mathbf{x} + b
+$$
+
+$$
+\hat{y} = \sigma(z) = \frac{1}{1 + e^{-z}}
+$$
+
+$\hat{y}$는 "이 샘플이 클래스 1에 속할 확률"로 해석한다. 예측 레이블은 $\hat{y} \geq 0.5$면 1, 아니면 0으로 정한다.
+
+# BCE (Binary Cross-Entropy) 손실 함수
+
+선형 회귀에서는 MSE를 썼지만 분류에서는 **Binary Cross-Entropy**를 쓴다.
+
+$$
+L = -\frac{1}{n} \sum_{i=1}^{n} \left[ y_i \log(\hat{y}_i) + (1 - y_i) \log(1 - \hat{y}_i) \right]
+$$
+
+처음 보면 생김새가 당황스럽지만 $y$가 0 또는 1이라는 점을 이용하면 **둘 중 한 항만 살아남는 구조**라는 게 보인다.
+
+- $y = 1$일 때: $(1-y) = 0$이므로 뒷항이 사라지고 $L_i = -\log(\hat{y}_i)$만 남는다.
+- $y = 0$일 때: $y = 0$이므로 앞항이 사라지고 $L_i = -\log(1 - \hat{y}_i)$만 남는다.
+
+즉 BCE는 "정답 클래스에 모델이 부여한 확률에 $-\log$를 씌운 값의 평균"이다. 정답에 높은 확률을 주면 보상(낮은 loss), 낮은 확률을 주면 벌(높은 loss).
+
+## 왜 $-\log$인가
+
+$-\log$ 함수는 확률에 대한 "상벌 함수"로 설계된 것처럼 딱 들어맞는 성질을 가지고 있다.
+
+- $\log(1) = 0$: 완벽한 예측($\hat{y} = 1$)일 때 벌점 0.
+- $\log(0) = -\infty$: 완전히 틀린 예측($\hat{y} \to 0$)일 때 벌점 무한대.
+- **0 근처에서 급격히 감소**: "약간 틀림"과 "자신만만하게 틀림"을 다르게 처벌.
+
+정답이 $y = 1$인 샘플 기준으로 예측 확률별 loss를 계산해 보면 이 비대칭성이 뚜렷하다.
+
+| 예측 $\hat{y}$ | $-\log(\hat{y})$ | 해석          |
+| -------------- | ---------------- | ------------- |
+| 0.99           | 0.01             | 거의 맞춤     |
+| 0.5            | 0.69             | 찍은 수준     |
+| 0.1            | 2.30             | 꽤 틀림       |
+| 0.01           | 4.61             | 심하게 틀림   |
+| 0.001          | 6.91             | 확신하며 틀림 |
+
+확률이 10배 낮아질 때마다 loss가 일정량씩 쌓인다. "반반 확신에서 10% 확신으로 가는 것"보다 "10% 확신에서 1% 확신으로 가는 것"이 더 큰 실수라는 직관을 수치로 반영한다.
+
+또한 로그는 **곱을 합으로 바꾸는** 성질이 있다.
+
+$$
+\log(\hat{y}_1 \cdot \hat{y}_2 \cdots \hat{y}_n) = \log(\hat{y}_1) + \log(\hat{y}_2) + \cdots + \log(\hat{y}_n)
+$$
+
+확률론적으로 보면 모든 샘플을 맞출 확률을 최대화하는 것이 목표인데 독립 샘플이면 이것은 확률들의 곱이다. 샘플이 많으면 이 곱은 극도로 작아져서 부동소수점 언더플로우가 발생한다. 로그를 씌워 합으로 바꾸면 수치적으로 안정적으로 최적화할 수 있다.
+
+BCE의 밑은 관례적으로 **자연로그** $\ln$이다. 밑을 바꿔도 loss는 상수배만 되고 learning rate가 이를 흡수하므로 최적화 결과는 동일하지만 미분이 깔끔한 $\ln$이 표준이다. NumPy의 `np.log`도 기본이 자연로그다.
+
+# 기울기 유도
+
+경사하강법을 적용하려면 $L$을 $\mathbf{w}$와 $b$에 대해 미분해야 한다. 그런데 BCE 식만 보면 $\mathbf{w}, b$가 보이지 않는다. $\hat{y}$ 속에 숨어 있기 때문이다.
+
+$$
+\hat{y} = \sigma(\mathbf{w}^\top \mathbf{x} + b)
+$$
+
+즉 $L$은 $\mathbf{w}, b$의 **합성함수**이고 체인룰로 미분한다.
+
+$$
+\frac{\partial L}{\partial \mathbf{w}} = \frac{\partial L}{\partial \hat{y}} \cdot \frac{\partial \hat{y}}{\partial z} \cdot \frac{\partial z}{\partial \mathbf{w}}
+$$
+
+샘플 한 개 기준으로 세 조각을 차례로 구한다.
+
+## 1단계: $\partial L / \partial \hat{y}$
+
+$L = -y \log(\hat{y}) - (1-y) \log(1 - \hat{y})$ 를 $\hat{y}$로 미분한다.
+
+$$
+\frac{\partial L}{\partial \hat{y}} = -\frac{y}{\hat{y}} + \frac{1-y}{1-\hat{y}}
+$$
+
+공통분모 $\hat{y}(1 - \hat{y})$로 통일하고 분자를 전개하면
+
+$$
+\frac{\partial L}{\partial \hat{y}} = \frac{-y(1-\hat{y}) + (1-y)\hat{y}}{\hat{y}(1-\hat{y})} = \frac{\hat{y} - y}{\hat{y}(1-\hat{y})}
+$$
+
+분모에 **$\hat{y}(1-\hat{y})$가 생긴 것**이 포인트다. 다음 단계와 소거된다.
+
+## 2단계: $\partial \hat{y} / \partial z$ (시그모이드 미분)
+
+시그모이드의 도함수는 자기 자신으로 표현되는 유명한 형태다.
+
+$$
+\frac{\partial \hat{y}}{\partial z} = \sigma(z)(1 - \sigma(z)) = \hat{y}(1 - \hat{y})
+$$
+
+## 3단계: $\partial z / \partial \mathbf{w}$
+
+$z = \mathbf{w}^\top \mathbf{x} + b$ 이므로 $\mathbf{w}$의 계수인 $\mathbf{x}$만 남는다.
+
+$$
+\frac{\partial z}{\partial \mathbf{w}} = \mathbf{x}
+$$
+
+## 조각 합치기: 기적의 소거
+
+세 조각을 곱하면
+
+$$
+\frac{\partial L}{\partial \mathbf{w}} = \frac{\hat{y} - y}{\hat{y}(1-\hat{y})} \cdot \hat{y}(1-\hat{y}) \cdot \mathbf{x} = (\hat{y} - y) \mathbf{x}
+$$
+
+1단계에서 생긴 분모 $\hat{y}(1-\hat{y})$와 2단계의 $\hat{y}(1-\hat{y})$가 정확히 상쇄된다. BCE와 시그모이드를 짝지어 쓰는 실용적인 이유가 바로 이것이다. MSE에 시그모이드를 붙이면 이 소거가 일어나지 않아 학습 초기 기울기가 매우 작아진다.
+
+$b$도 같은 방식으로 유도하면 $\partial z / \partial b = 1$이므로
+
+$$
+\frac{\partial L}{\partial b} = \hat{y} - y
+$$
+
+$n$개 샘플에 대해 평균 내고 벡터화하면 문제에서 주어진 공식이 된다.
+
+$$
+\frac{\partial L}{\partial \mathbf{w}} = \frac{1}{n} X^\top (\hat{\mathbf{y}} - \mathbf{y})
+$$
+
+$$
+\frac{\partial L}{\partial b} = \frac{1}{n} \sum_{i=1}^{n} (\hat{y}_i - y_i)
+$$
+
+선형 회귀 때와 달리 계수 $2$가 없는 이유는 BCE 정의에서 제곱이 없기 때문이다. 손실 함수가 바뀌었을 뿐 "오차 $\hat{y} - y$에 입력을 곱해 기울기를 얻는다"는 구조는 동일하다.
+
+# NumPy 구현
+
+```python
+import numpy as np
+
+def sigmoid(z):
+    return 1 / (1 + np.exp(-z))
+
+def logistic_regression(X, y, lr=0.01, n_iters=1000):
+    """
+    Returns:
+        tuple: (weights, bias) where weights is a list and bias is a float
+    """
+    X = np.asarray(X, dtype=float)
+    y = np.asarray(y, dtype=float)
+
+    n_samples, n_features = X.shape
+
+    w = np.zeros(n_features)
+    b = 0.0
+
+    for _ in range(n_iters):
+        z = X @ w + b
+        y_hat = sigmoid(z)
+        error = y_hat - y
+
+        dw = X.T @ error / n_samples
+        db = np.sum(error) / n_samples
+
+        w -= lr * dw
+        b -= lr * db
+
+    return w.tolist(), float(b)
+```
+
+선형 회귀 구현과 거의 동일한 뼈대 위에 **시그모이드 한 줄**만 추가된 구조다. 기울기 공식에서 계수 $2/n$이 $1/n$로 바뀐 것을 제외하면 업데이트 로직도 같다.
+
+## 반환 타입 맞추기
+
+```python
+return w.tolist(), float(b)
+```
+
+문제의 docstring은 `weights is a list and bias is a float`을 요구한다. `w`는 `numpy.ndarray`이고 `b`는 `b -= lr * db` 과정에서 `numpy.float64`로 바뀌므로 파이썬 기본 타입으로 명시적으로 변환해야 한다. 채점기가 `isinstance(b, float)` 같은 검사를 하면 `numpy.float64`는 통과하지 못할 수 있다.
+
+## 시그모이드 오버플로우
+
+```python
+def sigmoid(z):
+    return 1 / (1 + np.exp(-z))
+```
+
+$z$가 매우 큰 음수이면 `np.exp(-z)`가 오버플로우해서 `RuntimeWarning`이 뜬다. 결과 자체는 여전히 $1 / \infty = 0$으로 수렴하므로 수학적으로는 맞지만 경고를 없애고 싶다면 $z$의 부호에 따라 분기한다.
+
+```python
+def sigmoid(z):
+    return np.where(
+        z >= 0,
+        1 / (1 + np.exp(-z)),
+        np.exp(z) / (1 + np.exp(z)),
+    )
+```
+
+$z \geq 0$이면 $-z \leq 0$이므로 $e^{-z} \leq 1$로 안전하고 $z < 0$이면 $e^z < 1$로 안전하다. 두 식은 분자/분모에 $e^z$를 곱한 관계라 수학적으로 동일하다.
+
+## 학습률과 반복 횟수
+
+기본값 `lr=0.01`, `n_iters=1000`은 문제에서 요구한 값이다. 실제로는 데이터 스케일에 따라 튜닝이 필요하다. 입력 특성의 스케일이 크면 `z`가 쉽게 포화 영역(시그모이드의 양 끝)으로 가서 기울기가 소실되므로 학습 전 표준화(standardization)를 하는 것이 일반적이다.
+
+# 예측과 임계값
+
+위 구현은 **학습**만 담당한다. 실제로 새로운 입력을 0 또는 1로 분류하려면 학습된 $\mathbf{w}, b$로 확률을 계산한 뒤 임계값을 적용해야 한다.
+
+```python
+def predict(X, w, b, threshold=0.5):
+    y_hat = sigmoid(X @ w + b)             # 확률 (0~1)
+    return (y_hat >= threshold).astype(int) # 0 또는 1
+```
+
+학습 중에는 $\hat{y}$를 **실수 확률 그대로** 사용했다는 점을 짚을 필요가 있다. 손실과 기울기 계산은 $\hat{y}$가 연속값이라는 전제 위에서 돌아간다.
+
+- $\hat{y}$를 0/1로 먼저 바꾸면 **미분이 불가능**해진다. 계단 함수는 불연속이라 기울기가 없다.
+- BCE 공식 자체가 $\log(\hat{y})$를 요구하는데 $\hat{y}$가 0이면 $\log(0) = -\infty$로 발산한다.
+- 실수 확률을 써야 "얼마나 확신했는지"가 기울기 크기에 반영된다. 0.51로 간신히 맞춘 것과 0.99로 확실히 맞춘 것이 학습에 다르게 기여해야 한다.
+
+0/1로의 변환은 **학습이 끝난 뒤** 분류 결과를 꺼내는 단계에서만 일어난다.
+
+## 왜 기본 임계값이 0.5인가
+
+시그모이드의 중간점이 0.5이기 때문이다.
+
+$$
+\sigma(0) = 0.5
+$$
+
+즉 $z = \mathbf{w}^\top \mathbf{x} + b > 0$이면 $\hat{y} > 0.5$가 되어 클래스 1로 분류되고 그 반대면 클래스 0으로 분류된다. 결정 경계(decision boundary)는 정확히
+
+$$
+\mathbf{w}^\top \mathbf{x} + b = 0
+$$
+
+이라는 초평면이다. 0.5는 이 초평면을 기준으로 자연스럽게 양쪽을 나누는 값이다.
+
+## 임계값은 예측 시 사용자가 정하는 값
+
+중요한 포인트는 **임계값이 모델의 일부가 아니라는 것**이다. 학습된 $\mathbf{w}, b$는 "확률을 뱉는 함수"까지만 정의하고 그 확률을 어느 선에서 자를지는 별개의 결정이다.
+
+```python
+y_hat = sigmoid(X_test @ w + b)
+# 같은 모델로 다양한 임계값 정책을 적용할 수 있다
+
+y_pred_strict = (y_hat >= 0.9).astype(int)   # 확실할 때만 1
+y_pred_default = (y_hat >= 0.5).astype(int)  # 기본
+y_pred_loose = (y_hat >= 0.3).astype(int)    # 조금만 의심돼도 1
+```
+
+재학습 없이 임계값만 바꾸면 precision과 recall이 달라진다. ROC 곡선이나 PR 곡선을 그리는 것도 결국 임계값을 0에서 1까지 쓸어가며 성능을 측정하는 작업이다.
+
+상황에 따른 선택은 대체로 이런 식이다.
+
+- **암 진단**: 놓치면 치명적이므로 임계값을 낮춰서 "조금만 의심돼도 양성"으로 판단 (재현율 우선).
+- **스팸 필터**: 정상 메일을 스팸 처리하면 불편하므로 임계값을 높여서 "확실할 때만 스팸"으로 판단 (정밀도 우선).
+
+따라서 0.5는 "시그모이드의 중간점"이라는 수학적 편의에서 온 기본값일 뿐 언제나 최적이라는 뜻은 아니다. 실제 운영에서는 검증 데이터에서 F1 score, 비용 함수 등을 기준으로 임계값을 따로 튜닝한다.
+
+# 선형 회귀와 나란히 두고 비교
+
+두 모델을 나란히 놓으면 구조가 거의 같다는 것이 선명하게 보인다.
+
+|           | 선형 회귀                                            | 로지스틱 회귀                                        |
+| --------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| 출력      | $\hat{y} = \mathbf{w}^\top \mathbf{x} + b$           | $\hat{y} = \sigma(\mathbf{w}^\top \mathbf{x} + b)$   |
+| 정답 타입 | 실수                                                 | 0 또는 1                                             |
+| 손실 함수 | MSE                                                  | BCE                                                  |
+| $dw$ 공식 | $\frac{2}{n} X^\top (\hat{\mathbf{y}} - \mathbf{y})$ | $\frac{1}{n} X^\top (\hat{\mathbf{y}} - \mathbf{y})$ |
+| $db$ 공식 | $\frac{2}{n} \sum (\hat{y}_i - y_i)$                 | $\frac{1}{n} \sum (\hat{y}_i - y_i)$                 |
+
+손실 함수와 활성화 함수가 모두 바뀌었는데 기울기 공식이 거의 똑같다는 것이 이 조합을 짝지어 설계한 결과다. 구현 관점에서는 시그모이드 호출 한 줄만 추가하면 분류 모델이 된다.
+
+# 마무리
+
+이번 구현에서 가장 와닿은 점은 **$\hat{y}$ 속에 $\mathbf{w}, b$가 숨어 있다**는 것이다. BCE 식만 보면 파라미터가 없어 보이지만 합성함수 구조를 따라가면 체인룰이 자연스럽게 적용된다. 그리고 BCE와 시그모이드의 도함수가 서로를 상쇄시키는 설계 덕분에 최종 기울기는 "오차 × 입력"이라는 단순한 형태로 떨어진다.
+
+선형 회귀에서 "예측 → 오차 → 기울기 → 업데이트"라는 경사하강법의 뼈대를 배웠다면 로지스틱 회귀는 그 뼈대 위에 시그모이드와 BCE를 올려 분류로 확장하는 사례다. 여기서 은닉층을 쌓고 활성화를 교체하면 바로 신경망으로 이어진다.


### PR DESCRIPTION
## 변경 사항
- TensorTonic의 Logistic Regression 문제 풀이를 기반으로 한 로지스틱 회귀 포스트 추가 (`data/blog/ML/logistic-regression-from-scratch.mdx`)
  - BCE(Binary Cross-Entropy) 손실 함수 해설과 `-log`를 쓰는 이유를 로그의 성질과 연결
  - 체인룰로 `∂L/∂w` 유도: BCE 도함수의 `ŷ(1-ŷ)` 분모와 시그모이드 도함수가 소거되어 `(ŷ - y)x`로 떨어지는 과정
  - `numpy.ndarray` / `numpy.float64` 반환 타입을 파이썬 `list` / `float`로 변환하는 이유
  - 시그모이드 오버플로우 방지를 위한 `z` 부호 분기 구현
  - 예측 시 0.5 임계값의 의미(시그모이드 중간점, 결정 경계)와 임계값이 학습된 모델과 분리된 사용자 결정이라는 점
  - 선형 회귀와의 비교 표로 구조적 유사성 정리

## 변경 유형
- [x] 새 포스트
- [ ] 포스트 수정
- [ ] 기능 추가/변경
- [ ] 버그 수정
- [ ] 설정/의존성 변경

## 확인 사항
- [ ] 로컬에서 빌드(\`yarn build\`) 정상 동작
- [ ] 브라우저에서 변경 내용 확인