### PR TITLE
docs(blog): 시그모이드 포스트 인트로 문구 위치 통일

### DIFF
--- a/data/blog/ML/sigmoid-function.mdx
+++ b/data/blog/ML/sigmoid-function.mdx
@@ -6,9 +6,9 @@ draft: false
 summary: Sigmoid
 ---
 
-# 시그모이드 함수란?
-
 [TensorTonic의 Sigmoid 문제](https://www.tensortonic.com/problems/sigmoid-numpy)를 풀면서 시그모이드 함수에 대해 정리해 보았다.
+
+# 시그모이드 함수란?
 
 시그모이드(Sigmoid) 함수는 임의의 실수 입력을 받아 0과 1 사이의 값으로 변환하는 S자 형태의 함수다.
 


### PR DESCRIPTION
## 변경 사항
- `data/blog/ML/sigmoid-function.mdx`: TensorTonic 문제 소개 문구를 첫 헤딩 위로 이동해 선형 회귀/로지스틱 회귀 포스트와 구조 통일

## 변경 유형
- [x] 포스트 수정

## 확인 사항
- [ ] 로컬에서 빌드(\`yarn build\`) 정상 동작
- [ ] 브라우저에서 변경 내용 확인